### PR TITLE
Support aeson >= 2.0.0.0

### DIFF
--- a/curl-aeson.cabal
+++ b/curl-aeson.cabal
@@ -38,7 +38,7 @@ library
   other-modules:     Network.Curl.Aeson.Internal
   other-extensions:  RecordWildCards, OverloadedStrings
   build-depends:     base ==4.*,
-                     aeson >= 0.6,
+                     aeson >= 2.0.0.0,
                      curl >=1.3 && <1.4,
                      -- Text and ByteString dependencies should be
                      -- in-line with aeson dependencies

--- a/src/Network/Curl/Aeson.hs
+++ b/src/Network/Curl/Aeson.hs
@@ -195,7 +195,7 @@ binaryPayload a b = Just $ Payload a b
 -- @
 (...) :: FromJSON b
          => Parser Object -- ^ Parser to JSON object to look into
-         -> Text          -- ^ Key to look for
+         -> Key          -- ^ Key to look for
          -> Parser b      -- ^ Parser to the resulting field
 (...) p s = do
   o <- p


### PR DESCRIPTION
Aeson >= 2.0.0.0 uses opaque Key newtype instead of Text.
Perhaps Hackage package needs to be updated too, as it's broken now with newer Aeson versions.
Fixes #3